### PR TITLE
Support for big endian files

### DIFF
--- a/ceda_cc/utils_c4.py
+++ b/ceda_cc/utils_c4.py
@@ -592,7 +592,15 @@ class checkGlobalAttributes(checkBase):
       self.checkId = ('003','variable_type')
 
       mipType = vocabs['variable'].getAttr( varName, varGroup, 'type' )
-      thisType = {'real':'float32', 'integer':'int32', 'float':'float32', 'double':'float64' }.get( mipType, mipType )
+      thisType = {
+        'real': 'float32',
+        'integer': 'int32',
+        'float': 'float32',
+        'double': 'float64',
+        '>f8': 'float64',
+        '>f4': 'float32',
+        '>i4': 'int32'
+      }.get( mipType, mipType )
       self.test( mipType is None or varAts[varName]['_type'] == thisType, 'Variable [%s/%s] not of type %s [%s]' % (varName,varGroup,str(thisType),varAts[varName]['_type']) )
     else:
       mipType = None

--- a/ceda_cc/utils_c4.py
+++ b/ceda_cc/utils_c4.py
@@ -596,12 +596,13 @@ class checkGlobalAttributes(checkBase):
         'real': 'float32',
         'integer': 'int32',
         'float': 'float32',
-        'double': 'float64',
-        '>f8': 'float64',
-        '>f4': 'float32',
-        '>i4': 'int32'
+        'double': 'float64'
       }.get( mipType, mipType )
-      self.test( mipType is None or varAts[varName]['_type'] == thisType, 'Variable [%s/%s] not of type %s [%s]' % (varName,varGroup,str(thisType),varAts[varName]['_type']) )
+      variable_type = varAts[varName]['_type']
+      if '>' in variable_type:
+        # Big endian!
+        variable_type = {'>f8': 'float64', '>f4': 'float32', '>i4': 'int32'}.get(variable_type, variable_type)
+      self.test( mipType is None or variable_type == thisType, 'Variable [%s/%s] not of type %s [%s]' % (varName,varGroup,str(thisType),variable_type) )
     else:
       mipType = None
 


### PR DESCRIPTION
In the current version, the checker does not work well with netCDFs saved as big endian. This is because netCDF/numpy name big endian and little endian data types differently. In case of a big endian netCDF, the following dictionary needs to be used:

```
variable_type = {'>f8': 'float64', '>f4': 'float32', '>i4': 'int32'}
```